### PR TITLE
add Y/U/V only mode for ordinary shader

### DIFF
--- a/src/qml/VideoWindow.qml
+++ b/src/qml/VideoWindow.qml
@@ -117,6 +117,24 @@ VideoWindow {
                 }
 
                 MenuItem {
+                    contentItem: ComboBox {
+                        id: componentDisplaySelector
+                        objectName: "componentDisplaySelector"
+                        model: ["RGB", "Y Only", "U Only", "V Only"]
+                        width: 160
+                        currentIndex: videoWindow.componentDisplayMode
+
+                        onCurrentIndexChanged: {
+                            videoWindow.componentDisplayMode = currentIndex;
+                        }
+                        onActivated: keyHandler.forceActiveFocus()
+                    }
+                }
+
+                MenuSeparator {
+                }
+
+                MenuItem {
                     text: "Close the Video"
                     onTriggered: videoWindow.requestRemove(videoWindow.videoId)
                 }

--- a/src/rendering/videoRenderer.cpp
+++ b/src/rendering/videoRenderer.cpp
@@ -106,9 +106,20 @@ QByteArray VideoRenderer::loadShaderSource(const QString& path) {
 
 void VideoRenderer::setColorParams(AVColorSpace space, AVColorRange range) {
     struct ColorParams {
-        int colorSpace, colorRange, padding[2];
+        int colorSpace, colorRange, componentDisplayMode, padding;
     };
-    ColorParams cp = {space, range, {0, 0}};
+    ColorParams cp = {space, range, m_componentDisplayMode, 0};
+    m_colorParamsBatch = m_rhi->nextResourceUpdateBatch();
+    m_colorParamsBatch->updateDynamicBuffer(m_colorParams.get(), 0, sizeof(cp), &cp);
+}
+
+void VideoRenderer::setComponentDisplayMode(int mode) {
+    m_componentDisplayMode = mode;
+    // Update the uniform buffer with the new display mode
+    struct ColorParams {
+        int colorSpace, colorRange, componentDisplayMode, padding;
+    };
+    ColorParams cp = {m_metaPtr->colorSpace(), m_metaPtr->colorRange(), mode, 0};
     m_colorParamsBatch = m_rhi->nextResourceUpdateBatch();
     m_colorParamsBatch->updateDynamicBuffer(m_colorParams.get(), 0, sizeof(cp), &cp);
 }

--- a/src/rendering/videoRenderer.h
+++ b/src/rendering/videoRenderer.h
@@ -14,6 +14,7 @@ class VideoRenderer : public QObject {
 
     void initialize(QRhi* rhi, QRhiRenderPassDescriptor* rp);
     void setColorParams(AVColorSpace space, AVColorRange range);
+    void setComponentDisplayMode(int mode); // 0=RGB, 1=Y only, 2=U only, 3=V only
     void uploadFrame(FrameData* frame);
     void renderFrame(QRhiCommandBuffer* cb, const QRect& viewport, QRhiRenderTarget* rt);
     void releaseBatch();
@@ -47,6 +48,7 @@ class VideoRenderer : public QObject {
     std::unique_ptr<QRhiShaderResourceBindings> m_resourceBindings;
     std::unique_ptr<QRhiBuffer> m_vbuf;
     float m_windowAspect = 0;
+    int m_componentDisplayMode = 0; // 0=RGB, 1=Y only, 2=U only, 3=V only
 
     QRhiResourceUpdateBatch* m_initBatch = nullptr;
     QRhiResourceUpdateBatch* m_frameBatch = nullptr;

--- a/src/ui/videoWindow.cpp
+++ b/src/ui/videoWindow.cpp
@@ -325,6 +325,20 @@ QString VideoWindow::videoResolution() const {
     return QString("%1x%2").arg(width).arg(height);
 }
 
+int VideoWindow::componentDisplayMode() const {
+    return m_componentDisplayMode;
+}
+
+void VideoWindow::setComponentDisplayMode(int mode) {
+    if (m_componentDisplayMode != mode) {
+        m_componentDisplayMode = mode;
+        if (m_renderer) {
+            m_renderer->setComponentDisplayMode(mode);
+        }
+        emit componentDisplayModeChanged();
+    }
+}
+
 QVariant VideoWindow::getYUV(int x, int y) const {
     if (!m_renderer)
         return QVariant();

--- a/src/ui/videoWindow.h
+++ b/src/ui/videoWindow.h
@@ -24,6 +24,8 @@ class VideoWindow : public QQuickItem {
     Q_PROPERTY(QString colorSpace READ colorSpace CONSTANT)
     Q_PROPERTY(QString colorRange READ colorRange CONSTANT)
     Q_PROPERTY(QString videoResolution READ videoResolution CONSTANT)
+    Q_PROPERTY(int componentDisplayMode READ componentDisplayMode WRITE setComponentDisplayMode NOTIFY
+                   componentDisplayModeChanged)
 
   public:
     explicit VideoWindow(QQuickItem* parent = nullptr);
@@ -49,6 +51,8 @@ class VideoWindow : public QQuickItem {
     QString colorSpace() const;
     QString colorRange() const;
     QString videoResolution() const;
+    int componentDisplayMode() const;
+    void setComponentDisplayMode(int mode);
 
   public slots:
     void uploadFrame(FrameData* frame);
@@ -80,6 +84,7 @@ class VideoWindow : public QQuickItem {
     void currentFrameChanged();
     void currentTimeMsChanged();
     void metadataInitialized();
+    void componentDisplayModeChanged();
 
   protected:
     QSGNode* updatePaintNode(QSGNode* oldNode, UpdatePaintNodeData*) override;
@@ -99,6 +104,7 @@ class VideoWindow : public QQuickItem {
     std::shared_ptr<FrameMeta> m_frameMeta;
     int m_currentFrame = 0;
     double m_currentTimeMs = 0.0;
+    int m_componentDisplayMode = 0; // 0=RGB, 1=Y only, 2=U only, 3=V only
 
     QRectF getVideoRect() const;
     QPointF convertToVideoCoordinates(const QPointF& point) const;


### PR DESCRIPTION
Allows user to inspect video in Y/U/V only mode.
Y: greystyle
U: green-blue
V: green-red
(same property to the picture on wiki)