### PR TITLE
Signal decoder stall

### DIFF
--- a/src/controller/frameController.cpp
+++ b/src/controller/frameController.cpp
@@ -52,11 +52,11 @@ FrameController::FrameController(QObject* parent, VideoFileInfo videoFileInfo, i
             &VideoRenderer::batchIsFull,
             this,
             &FrameController::onFrameUploaded,
-            Qt::DirectConnection);
+            Qt::QueuedConnection);
     // qDebug() << "Connected VideoRenderer::batchUploaded to FrameController::onFrameUploaded";
 
     // Request & Receive for uploading to GPU and rendering frames (same-thread communication)
-    connect(this, &FrameController::requestRender, m_window, &VideoWindow::renderFrame, Qt::DirectConnection);
+    connect(this, &FrameController::requestRender, m_window, &VideoWindow::renderFrame, Qt::QueuedConnection);
     // qDebug() << "Connected requestRender to VideoRenderer::renderFrame";
 
     connect(m_window->m_renderer,

--- a/src/controller/frameController.cpp
+++ b/src/controller/frameController.cpp
@@ -145,15 +145,6 @@ void FrameController::onTimerTick(int64_t pts, int direction) {
         qWarning() << "Cannot render frame" << pts;
     }
 
-    if (!(m_endOfVideo && direction == 1) && !(pts == 0 && direction == -1) && !m_decodeInProgress) {
-        // Request to decode more frames if needed
-        int framesToFill = m_frameQueue->getEmpty(direction);
-        qDebug() << "FC::Request decode for" << framesToFill << "in direction" << direction
-                 << "decodeInProgress set to true";
-        m_decodeInProgress = true;
-        emit requestDecode(framesToFill, direction);
-    }
-
     qDebug() << "\n";
 }
 
@@ -295,6 +286,15 @@ void FrameController::onFrameRendered() {
             emit requestUpload(future, m_index);
         } else {
             qWarning() << "Cannot upload frame" << (futurePts);
+        }
+
+        if (!(m_endOfVideo && m_direction == 1) && !(m_ticking == 0 && m_direction == -1) && !m_decodeInProgress) {
+            // Request to decode more frames if needed
+            int framesToFill = m_frameQueue->getEmpty(m_direction);
+            qDebug() << "FC::Request decode for" << framesToFill << "in direction" << m_direction
+                     << "decodeInProgress set to true";
+            m_decodeInProgress = true;
+            emit requestDecode(framesToFill, m_direction);
         }
     }
 }

--- a/src/controller/frameController.h
+++ b/src/controller/frameController.h
@@ -59,6 +59,7 @@ class FrameController : public QObject {
     void endOfVideo(bool end, int index);
     void requestSeek(int64_t pts, int loadCount);
     void seekCompleted(int index);
+    void decoderStalled(int index, bool stalled);
 
   private:
     // YUVReader to read frames from video file
@@ -91,4 +92,9 @@ class FrameController : public QObject {
     int64_t m_seeking = -1;
 
     bool m_decodeInProgress = false;
+
+    bool m_stalled = false;
+    int64_t m_waitingPTS = -1;
+
+    void clearStall();
 };

--- a/src/controller/videoController.cpp
+++ b/src/controller/videoController.cpp
@@ -296,18 +296,15 @@ void VideoController::play() {
             m_direction = 1;
             m_uiDirection = 1;
             seekTo(0.0);
-            // Return early instead of immediately play
-            return;
 
         } else {
             // qDebug() << "VideoController::Starting playback in reverse";
             m_direction = -1;
             m_uiDirection = -1;
             seekTo(m_realEndMs);
-
-            // For some reason (likely race condition) we cannot return earlier here
-            // Otherwise playback does not start correctly
         }
+        // Return early instead of immediately play
+        return;
     }
 
     m_isPlaying = true;

--- a/src/controller/videoController.h
+++ b/src/controller/videoController.h
@@ -29,6 +29,7 @@ class VideoController : public QObject {
     Q_PROPERTY(bool isForward READ isForward NOTIFY directionChanged)
     Q_PROPERTY(bool ready READ ready NOTIFY readyChanged)
     Q_PROPERTY(bool isSeeking READ isSeeking NOTIFY seekingChanged)
+    Q_PROPERTY(bool isBuffering READ isBuffering NOTIFY isBufferingChanged)
 
   public:
     VideoController(QObject* parent,
@@ -44,6 +45,7 @@ class VideoController : public QObject {
     bool isForward() const { return m_uiDirection == 1; }
     bool ready() const { return m_ready; }
     bool isSeeking() const { return m_isSeeking; }
+    bool isBuffering() const { return m_isBuffering; }
 
     void addVideo(VideoFileInfo videoFileInfo);
     void setUpTimer();
@@ -68,6 +70,7 @@ class VideoController : public QObject {
     void removeVideo(int index);
     void setDiffMode(bool diffMode, int id1, int id2);
     void onSeekCompleted(int index);
+    void onDecoderStalled(int index, bool stalled);
 
   signals:
     void playTimer();
@@ -87,6 +90,7 @@ class VideoController : public QObject {
     void totalFramesChanged();
     void readyChanged();
     void seekingChanged();
+    void isBufferingChanged();
 
   private:
     std::vector<std::unique_ptr<FrameController>> m_frameControllers;
@@ -103,6 +107,7 @@ class VideoController : public QObject {
     QSet<int> m_startFCs;
     QSet<int> m_endFCs;
     QSet<int> m_seekedFCs;
+    QSet<int> m_stalledFCs;
 
     // Ensure all FC have uploaded initial frame before starting timer
     bool m_ready = false;
@@ -123,8 +128,10 @@ class VideoController : public QObject {
     bool m_diffMode = false;
 
     bool m_isSeeking = false;
-    int m_seekedCount = 0;
     bool m_pendingPlay = false;
+
+    bool m_wasPlayingWhenStalled = false;
+    bool m_isBuffering = false;
 
     std::shared_ptr<CompareController> m_compareController;
 };

--- a/src/controller/videoController.h
+++ b/src/controller/videoController.h
@@ -117,6 +117,7 @@ class VideoController : public QObject {
     int m_totalFrames = 0;
 
     int64_t m_currentTimeMs = 0;
+    int64_t m_realEndMs = 0;
 
     // 1 for forward, -1 for backward
     int m_direction = 1;

--- a/src/controller/videoController.h
+++ b/src/controller/videoController.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QElapsedTimer>
+#include <QSet>
 #include <QThread>
 #include <QVariant>
 #include <QtConcurrent>
@@ -98,12 +99,13 @@ class VideoController : public QObject {
 
     QThread m_timerThread;
 
-    // Ensure all FC have uploaded initial frame before starting timer
-    int m_readyCount = 0;
-    bool m_ready = false;
+    QSet<int> m_readyFCs;
+    QSet<int> m_startFCs;
+    QSet<int> m_endFCs;
+    QSet<int> m_seekedFCs;
 
-    int m_startCount = 0;
-    int m_endCount = 0;
+    // Ensure all FC have uploaded initial frame before starting timer
+    bool m_ready = false;
 
     int64_t m_duration = 0;
 

--- a/src/decoder/videoDecoder.cpp
+++ b/src/decoder/videoDecoder.cpp
@@ -277,6 +277,9 @@ void VideoDecoder::loadFrames(int num_frames, int direction = 1) {
     int64_t maxpts = -1;
     int64_t minpts = INT64_MAX;
 
+    qDebug() << "VideoDecoder::loadFrames called with num_frames: " << num_frames << ", direction: " << direction
+             << ", currentFrameIndex: " << currentFrameIndex;
+
     // Seek to correct frame before loading
     if (direction == -1) {
         if (currentFrameIndex == 0) {
@@ -298,9 +301,6 @@ void VideoDecoder::loadFrames(int num_frames, int direction = 1) {
     }
 
     localTail = currentFrameIndex;
-
-    qDebug() << "VideoDecoder::loadFrames called with num_frames: " << num_frames << ", direction: " << direction
-             << ", currentFrameIndex: " << currentFrameIndex;
 
     for (int i = 0; i < num_frames; ++i) {
         int64_t temp_pts;
@@ -351,12 +351,13 @@ void VideoDecoder::loadFrames(int num_frames, int direction = 1) {
         minpts = std::min(minpts, std::max(temp_pts, (int64_t)0));
     }
 
-    qDebug() << "VideoDecoder:: Loaded from " << localTail << " to " << currentFrameIndex;
+    qDebug() << "VideoDecoder:: Loaded from " << localTail << " to " << currentFrameIndex << " in direction "
+             << direction;
 
     if (direction == 1) {
         m_frameQueue->updateTail(maxpts);
     } else {
-        m_frameQueue->updateTail(minpts);
+        m_frameQueue->updateTail(maxpts);
     }
 
     emit framesLoaded(true);
@@ -616,7 +617,7 @@ int64_t VideoDecoder::loadCompressedFrame() {
                     // Set pts to normalized pts
                     frameData->setPts(normalized_pts);
                     frameData->setEndFrame(false);
-                    currentFrameIndex = normalized_pts;
+                    currentFrameIndex = normalized_pts + 1;
 
                     // qDebug() << "VideoDecoder::loadCompressedFrame loaded frame" << normalized_pts << "from raw PTS"
                     //          << raw_pts << "at queue index" << normalized_pts;

--- a/src/qml/VideoWindow.qml
+++ b/src/qml/VideoWindow.qml
@@ -523,14 +523,14 @@ VideoWindow {
 
     // Loading Indicator
     Rectangle {
-        visible: videoController && (!videoController.ready || videoController.isSeeking)
+        visible: videoController && (!videoController.ready || videoController.isSeeking || videoController.isBuffering)
         anchors.centerIn: parent
         width: loadingText.width + 40
         height: loadingText.height + 20
         color: "black"
         opacity: 0.8
         radius: 8
-        z: 102 // On top of everything
+        z: 102
 
         Text {
             id: loadingText


### PR DESCRIPTION
This PR includes

- add a stalling signal and pause playback when decoder is catching up
- fix to "loading..." text not showing when loading new videos
- fix to reverse play for both raw and compressed format
- safeguard seeking to frame exceeding total frames
- fix reverse playing at EoV